### PR TITLE
Fix `r` on the all-teams board, and `g` leaving group headers off-screen

### DIFF
--- a/ltui/ltui.py
+++ b/ltui/ltui.py
@@ -694,6 +694,23 @@ class NavList(OptionList):
                     self.highlighted = j
                     return
 
+    def action_first(self) -> None:
+        """Jump to the top of the list, not just to the first *option*.
+
+        OptionList.action_first only assigns `highlighted`, so when the
+        highlight already sits on the first enabled row the reactive never
+        changes and nothing scrolls — leaving the disabled group header above
+        it stranded off-screen. Scroll home regardless of where the highlight
+        was: `g` means the top of the list.
+        """
+        super().action_first()
+        self.scroll_home(animate=False)
+
+    def action_last(self) -> None:
+        """Mirror of `action_first` for `G`."""
+        super().action_last()
+        self.scroll_end(animate=False)
+
     def action_page_down(self) -> None:
         super().action_page_down()
         self._snap_to_enabled(1)
@@ -2562,7 +2579,7 @@ class LTUI(App):
     # ── actions ───────────────────────────────────────────────────────
     def action_refresh(self) -> None:
         if self._team:
-            self.load_team(self._team)
+            self._load_scope(self._team)
 
     def _tick_fx(self) -> None:
         if not CONFIG_OPTIONS.get("animations", True):


### PR DESCRIPTION
Both of these come from @blakejgruber's test report on #5 — a 9-team, 1,152-issue workspace, which is about 5x the exercise my own 2-team setup gives this.

## `r` never refreshed the all-teams board

`_load_scope` is the branch that routes `ALL_TEAMS_ID` to `load_all_teams`, and the staleness poll checks `_all_teams` before it picks a loader — but `action_refresh` called `load_team` unconditionally. So on the all-teams board `r` sent `teamId: "*"` straight to Linear, the one thing that id is documented never to do:

```
linear: Entity not found: Team
```

There's a second-order effect worth noting, because it outlives the failed fetch: `load_team` stamps the border title *before* it awaits, and its error path returns early, so the title degraded from `ALL · 9 teams` to `ALL · all teams` (`ALL_TEAMS` carries `name: "all teams"`) and stayed wrong until you switched boards and came back.

```diff
 def action_refresh(self) -> None:
     if self._team:
-        self.load_team(self._team)
+        self._load_scope(self._team)
```

Blake's read on why it survived my own testing is right: on a 2-team board you press `r` maybe once and blame the network.

## `g` couldn't bring a group header back into view

`NavList` binds `g` to Textual's `OptionList.action_first`, which is just:

```python
self.highlighted = _widget_navigation.find_first_enabled(self.options)
```

Group headers are disabled options, so after `v` re-groups the highlight is already on the first *enabled* row. Assigning the same value doesn't change the reactive, `watch_highlighted` never fires, nothing scrolls — and the header sitting above it stays stranded off-screen. With a 78-issue first bucket that reads as 78 headerless rows until you jump to the next group and back.

Digging into it, `g` from mid-list didn't actually fix it either. `scroll_to_highlight` calls `scroll_to_region(..., top=False)`, so it scrolls the minimum needed to reveal the highlighted *row* and still clips the header above by a line. `g` now scrolls home outright, with `G` mirrored for symmetry:

```python
def action_first(self) -> None:
    super().action_first()
    self.scroll_home(animate=False)
```

Not a regression from the all-teams work — it reproduces in project mode on a single-team board — but a cross-team board makes it loud.

## Testing

Wrote a headless Textual check for both, and ran it against the code *before* this diff as well to make sure it wasn't vacuously green. Before: 4 failures. After: 10/10.

```
PASS  r on all-teams board does NOT send teamId='*' to the API  (calls=[('load_all_teams', None)])
PASS  r on all-teams board calls load_all_teams
PASS  r on a single-team board still calls load_team  (calls=[('load_team', 'team-abc')])
PASS  r with no board selected is a no-op  (calls=[])
PASS  setup: header is off-screen with the highlight already first  (scroll_y=40 highlighted=1)
PASS  g brings the group header back into view  (scroll_y=0)
PASS  g leaves the highlight on the first enabled row (not the header)  (highlighted=1)
PASS  G still lands on the last enabled row  (highlighted=80)
PASS  G scrolls to the end  (scroll_y=59 max=59)
PASS  g from mid-list still goes to the top  (scroll_y=0 highlighted=1)
```

The `r` cases drive the real `_load_scope`, and the `g`/`G` cases drive a real `NavList` with its real bindings through a Textual pilot, reproducing the post-`v` state: highlight on the first enabled row, list scrolled past the header.

Not touching the team-colour tint idea from the same comment here — that's a design call, not a defect, and it deserves its own diff.
