### PR TITLE
Add `x` — run a custom script on the highlighted ticket

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ launch ──▶ render cached board (~50ms) ──▶ you're already working
 | 🏷️  | **label editing** — `l` opens a multi-select editor over your tracker's labels |
 | 👥  | **assign without leaving** — `a` reassigns to anyone on the team, or you, or nobody |
 | 🌿  | **`y` yanks a git branch** — ticket → `git checkout -b` in seconds |
+| 🚀  | **`x` runs your own script** — hand the ticket to a coding agent or any tool, reusing Linear's `coding-tools.json` hook |
 | 🌳  | **hierarchy aware** — parent tickets, sub-issues/subtasks with done-counts, and blocked/blocking badges with the exact tickets named |
 | 📖  | **rich detail panel** — full markdown descriptions, labels, comments — scrolls with arrows, vim keys, or mouse |
 | ✏️  | **write, don't just read** — create tickets, change status & priority, comment, all from the keyboard |

--- a/ltui/README.md
+++ b/ltui/README.md
@@ -53,6 +53,7 @@ launch. ltui doesn't:
 | 🎯  | **initiative view** — press `v` again to group by **initiative**, the level above projects: every project's tickets gathered under the goal they ladder up to, live initiatives first |
 | 🌐  | **every team at once** — the top row of the teams pane is **all teams**: one board spanning your whole workspace, with each team's `In Progress` merged into a single group instead of one per team |
 | 🌿  | **`y` yanks the git branch** — Linear's generated branch name straight to your clipboard (or the URL / identifier); ticket → `git checkout -b` in seconds |
+| 🚀  | **`x` hands the ticket to your tools** — runs the same `~/.linear/coding-tools.json` script Linear's desktop *Work on issue → Custom script* fires, with the same `LINEAR_*` variables and your Prompt template, so one script serves both |
 | 👥  | **assign without leaving** — `a` reassigns to anyone on the team, or you, or nobody |
 | 🌳  | **hierarchy aware** — the detail panel shows the parent ticket and all sub-issues with a done-count, next to blocked/blocking relations |
 | 🔄  | **never stale** — the board silently re-syncs every 3 minutes |
@@ -155,6 +156,7 @@ and `?` opens the full keybinding cheatsheet whenever you need it.
 | `c`      | add a **comment** (`ctrl+s` to send)          |
 | `o`      | open ticket in **browser**                    |
 | `y`      | **yank** — copy branch name / url / id        |
+| `x`      | **run your custom script** on the ticket      |
 | `/`      | filter issues                                 |
 | `m`      | toggle **mine only**                          |
 | `v`      | cycle grouping: **status → project → initiative** |
@@ -236,6 +238,47 @@ ltui --init-config    # writes ~/.config/ltui/config.json
   }
 }
 ```
+
+### custom script (`x`)
+
+`x` runs a local script against the highlighted ticket. It reads the same file
+Linear's desktop app uses for **Work on issue → Custom script**, so if you have
+that set up already there is nothing new to configure:
+
+```jsonc
+// ~/.linear/coding-tools.json
+{
+  "openIssue": {
+    "path": "/absolute/path/to/your-script",
+    "args": ["--branch", "{{issue.branchName}}"],   // {{...}} interpolated
+    "env": ["LINEAR_PROMPT", "LINEAR_ISSUE_IDENTIFIER", "LINEAR_ISSUE_BRANCH_NAME"]
+  }
+}
+```
+
+Placeholders for `args`: `{{issue.identifier}}`, `{{issue.branchName}}`,
+`{{issue.title}}`, `{{issue.url}}`, `{{project.name}}`, `{{context}}`,
+`{{prompt}}`, `{{workDir}}`.
+
+The `env` list is an allowlist selecting which of `LINEAR_ISSUE_IDENTIFIER`,
+`LINEAR_ISSUE_BRANCH_NAME`, `LINEAR_ISSUE_TITLE`, `LINEAR_ISSUE_URL`,
+`LINEAR_PROJECT_NAME`, `LINEAR_PROMPT` and `LINEAR_WORK_DIR` are exported; omit
+it to export all of them. `LINEAR_TOOL_COMMAND=ltui` is always set, so a shared
+script can tell the TUI apart from the desktop app.
+
+`LINEAR_PROMPT` is rendered from `~/.linear/prompt-template.txt` if present —
+the equivalent of Linear's **Prompt template** setting — falling back to
+`{{context}}` (the ticket's title and description). For example:
+
+```
+Read Linear issue {{issue.identifier}} and await further instructions.
+
+{{context}}
+```
+
+The script is detached from the TUI's terminal, so it will not fight ltui for
+the tty; have it log somewhere or open a window of its own.
+
 
 key names are [Textual key names](https://textual.textualize.io/guide/input/#key)
 (`slash`, `comma`, `question_mark`, `ctrl+x`, …). unknown or invalid entries

--- a/ltui/README.md
+++ b/ltui/README.md
@@ -263,8 +263,13 @@ Placeholders for `args`: `{{issue.identifier}}`, `{{issue.branchName}}`,
 The `env` list is an allowlist selecting which of `LINEAR_ISSUE_IDENTIFIER`,
 `LINEAR_ISSUE_BRANCH_NAME`, `LINEAR_ISSUE_TITLE`, `LINEAR_ISSUE_URL`,
 `LINEAR_PROJECT_NAME`, `LINEAR_PROMPT` and `LINEAR_WORK_DIR` are exported; omit
-it to export all of them. `LINEAR_TOOL_COMMAND=ltui` is always set, so a shared
-script can tell the TUI apart from the desktop app.
+it to export all of them. It governs the whole `LINEAR_` namespace, not just
+those seven: any other `LINEAR_*` variable in ltui's own environment — most
+importantly `LINEAR_API_KEY` — is withheld from your script unless you name it
+in the list, so handing it your credentials is a deliberate act rather than an
+accident. The rest of your environment is inherited as usual, and
+`LINEAR_TOOL_COMMAND=ltui` is always set, so a shared script can tell the TUI
+apart from the desktop app.
 
 `LINEAR_PROMPT` is rendered from `~/.linear/prompt-template.txt` if present —
 the equivalent of Linear's **Prompt template** setting — falling back to
@@ -278,7 +283,6 @@ Read Linear issue {{issue.identifier}} and await further instructions.
 
 The script is detached from the TUI's terminal, so it will not fight ltui for
 the tty; have it log somewhere or open a window of its own.
-
 
 key names are [Textual key names](https://textual.textualize.io/guide/input/#key)
 (`slash`, `comma`, `question_mark`, `ctrl+x`, …). unknown or invalid entries

--- a/ltui/ltui.py
+++ b/ltui/ltui.py
@@ -14,6 +14,8 @@ __version__ = "0.15.0"
 
 import asyncio
 import json
+import os
+import subprocess
 import sys
 import tomllib
 import webbrowser
@@ -38,6 +40,10 @@ API_URL = "https://api.linear.app/graphql"
 CONFIG = Path.home() / ".config/linear-cli/config.toml"
 LTUI_CONFIG = Path.home() / ".config/ltui/config.toml"
 LTUI_JSON_CONFIG = Path.home() / ".config/ltui/config.json"
+# Linear desktop's "Work on issue -> Custom script" hook; reused verbatim.
+LINEAR_CODING_TOOLS = Path.home() / ".linear/coding-tools.json"
+# Mirrors Linear's "Prompt template" setting so ltui builds the same prompt.
+LINEAR_PROMPT_TEMPLATE = Path.home() / ".linear/prompt-template.txt"
 STATE_FILE = Path.home() / ".local/state/ltui/state.json"
 CACHE_DIR = Path.home() / ".cache/ltui"
 AUTO_REFRESH_SECONDS = 180
@@ -383,6 +389,7 @@ DEFAULT_KEYBINDS = {
     "change_assignee": (["a"], None),
     "open_browser": (["o"], None),
     "yank": (["y"], None),
+    "run_script": (["x"], "script"),
     # vim layer (additive)
     "next_group": (["right_square_bracket"], None),
     "prev_group": (["left_square_bracket"], None),
@@ -441,6 +448,7 @@ CONFIG_TEMPLATE = """{
     "change_assignee": "a",
     "open_browser": "o",
     "yank": "y",
+    "run_script": "x",
     "next_group": "right_square_bracket",
     "prev_group": "left_square_bracket",
     "command_palette": "colon",
@@ -1236,6 +1244,7 @@ class HelpModal(ModalScreen):
             ("c", "add a comment (ctrl+s to send)"),
             ("y", "yank — copy branch / url / identifier"),
             ("o", "open in browser"),
+            ("x", "run custom script (~/.linear/coding-tools.json)"),
         ]),
         ("view", [
             ("/", "filter issues"),
@@ -3067,6 +3076,82 @@ class LTUI(App):
             webbrowser.open(issue["url"])
             self.notify(f" opened {issue['identifier']}")
 
+    def action_run_script(self) -> None:
+        """Run the local custom script from ~/.linear/coding-tools.json against
+        the selected issue — the same hook Linear desktop's "Work on issue →
+        Custom script" fires, with the same LINEAR_* env contract, so one
+        script serves both."""
+        issue = self._current_issue()
+        if not issue:
+            return
+        try:
+            cfg = json.loads(LINEAR_CODING_TOOLS.read_text()).get("openIssue") or {}
+        except FileNotFoundError:
+            self.notify(f" no {LINEAR_CODING_TOOLS}", severity="error")
+            return
+        except Exception as e:
+            self.notify(f" bad coding-tools.json: {e}", severity="error")
+            return
+        path = cfg.get("path")
+        if not path:
+            self.notify(" coding-tools.json: openIssue.path missing", severity="error")
+            return
+
+        title = issue.get("title") or ""
+        body = issue.get("description") or ""
+        tmpl = {
+            "issue.identifier": issue.get("identifier") or "",
+            "issue.branchName": issue.get("branchName") or issue.get("identifier", "").lower(),
+            "issue.title": title,
+            "issue.url": issue.get("url") or "",
+            "project.name": (issue.get("project") or {}).get("name") or "",
+            "context": f"{title}\n\n{body}".strip(),
+            "workDir": str(Path.cwd()),
+        }
+        # Linear renders its "Prompt template" setting before handing the
+        # script LINEAR_PROMPT; do the same so both entry points agree.
+        try:
+            template = LINEAR_PROMPT_TEMPLATE.read_text()
+        except Exception:
+            template = "{{context}}"
+        for k, v in tmpl.items():
+            template = template.replace("{{" + k + "}}", v)
+        tmpl["prompt"] = template.strip()
+
+        exported = {
+            "LINEAR_ISSUE_IDENTIFIER": tmpl["issue.identifier"],
+            "LINEAR_ISSUE_BRANCH_NAME": tmpl["issue.branchName"],
+            "LINEAR_ISSUE_TITLE": tmpl["issue.title"],
+            "LINEAR_ISSUE_URL": tmpl["issue.url"],
+            "LINEAR_PROJECT_NAME": tmpl["project.name"],
+            "LINEAR_PROMPT": tmpl["prompt"],
+            "LINEAR_WORK_DIR": tmpl["workDir"],
+        }
+        # Linear's semantics: an "env" list selects which vars to expose.
+        wanted = cfg.get("env")
+        if isinstance(wanted, list) and wanted:
+            exported = {k: v for k, v in exported.items() if k in wanted}
+
+        def interp(s: str) -> str:
+            for k, v in tmpl.items():
+                s = s.replace("{{" + k + "}}", v)
+            return s
+
+        argv = [str(path), *(interp(str(a)) for a in (cfg.get("args") or []))]
+        try:
+            subprocess.Popen(
+                argv,
+                env={**os.environ, **exported, "LINEAR_TOOL_COMMAND": "ltui"},
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,  # never fight the TUI for the tty
+            )
+        except Exception as e:
+            self.notify(f" script failed: {e}", severity="error")
+            return
+        self.notify(f" script launched for {issue['identifier']}")
+
     def action_yank(self) -> None:
         issue = self._current_issue()
         if not issue:
@@ -3110,6 +3195,7 @@ auth: LINEAR_API_KEY env var, ~/.config/ltui/config.toml, or
 
 keys: enter open ticket   n new   s status   p priority   c comment
       a assign   l labels   P project   o browser   y yank   / filter
+      x run ~/.linear/coding-tools.json custom script on the ticket
       m mine only   v group status/project/initiative
       V one project   t theme
       , settings   j/k navigate   g/G top/bottom   r refresh   ? help

--- a/ltui/ltui.py
+++ b/ltui/ltui.py
@@ -15,6 +15,7 @@ __version__ = "0.15.0"
 import asyncio
 import json
 import os
+import re
 import subprocess
 import sys
 import tomllib
@@ -44,6 +45,7 @@ LTUI_JSON_CONFIG = Path.home() / ".config/ltui/config.json"
 LINEAR_CODING_TOOLS = Path.home() / ".linear/coding-tools.json"
 # Mirrors Linear's "Prompt template" setting so ltui builds the same prompt.
 LINEAR_PROMPT_TEMPLATE = Path.home() / ".linear/prompt-template.txt"
+PLACEHOLDER = re.compile(r"\{\{([A-Za-z][\w.]*)\}\}")
 STATE_FILE = Path.home() / ".local/state/ltui/state.json"
 CACHE_DIR = Path.home() / ".cache/ltui"
 AUTO_REFRESH_SECONDS = 180
@@ -389,7 +391,7 @@ DEFAULT_KEYBINDS = {
     "change_assignee": (["a"], None),
     "open_browser": (["o"], None),
     "yank": (["y"], None),
-    "run_script": (["x"], "script"),
+    "run_script": (["x"], None),
     # vim layer (additive)
     "next_group": (["right_square_bracket"], None),
     "prev_group": (["left_square_bracket"], None),
@@ -464,8 +466,6 @@ CONFIG_TEMPLATE = """{
 
 
 def load_api_key() -> str:
-    import os
-
     if key := os.environ.get("LINEAR_API_KEY"):
         return key
     try:
@@ -3096,27 +3096,35 @@ class LTUI(App):
         if not path:
             self.notify(" coding-tools.json: openIssue.path missing", severity="error")
             return
+        path = Path(str(path)).expanduser()
 
         title = issue.get("title") or ""
         body = issue.get("description") or ""
         tmpl = {
             "issue.identifier": issue.get("identifier") or "",
-            "issue.branchName": issue.get("branchName") or issue.get("identifier", "").lower(),
+            "issue.branchName": (
+                issue.get("branchName") or (issue.get("identifier") or "").lower()
+            ),
             "issue.title": title,
             "issue.url": issue.get("url") or "",
             "project.name": (issue.get("project") or {}).get("name") or "",
             "context": f"{title}\n\n{body}".strip(),
             "workDir": str(Path.cwd()),
         }
+
+        def interp(s: str) -> str:
+            # one pass: a {{...}} that arrives *inside* ticket text — which
+            # anyone with workspace access can write — stays literal instead
+            # of being expanded on a later iteration.
+            return PLACEHOLDER.sub(lambda m: tmpl.get(m[1], m[0]), s)
+
         # Linear renders its "Prompt template" setting before handing the
         # script LINEAR_PROMPT; do the same so both entry points agree.
         try:
             template = LINEAR_PROMPT_TEMPLATE.read_text()
         except Exception:
             template = "{{context}}"
-        for k, v in tmpl.items():
-            template = template.replace("{{" + k + "}}", v)
-        tmpl["prompt"] = template.strip()
+        tmpl["prompt"] = interp(template).strip()
 
         exported = {
             "LINEAR_ISSUE_IDENTIFIER": tmpl["issue.identifier"],
@@ -3127,21 +3135,26 @@ class LTUI(App):
             "LINEAR_PROMPT": tmpl["prompt"],
             "LINEAR_WORK_DIR": tmpl["workDir"],
         }
-        # Linear's semantics: an "env" list selects which vars to expose.
+        # Linear's semantics: an "env" list selects which vars to expose. ltui
+        # owns the whole LINEAR_ namespace in the child, so what the allowlist
+        # leaves out is genuinely absent rather than inherited from our own
+        # environment behind the user's back — LINEAR_API_KEY above all. A
+        # name that isn't ours but is in our environment can still be listed
+        # explicitly, which makes passing the key along a deliberate act.
         wanted = cfg.get("env")
         if isinstance(wanted, list) and wanted:
-            exported = {k: v for k, v in exported.items() if k in wanted}
-
-        def interp(s: str) -> str:
-            for k, v in tmpl.items():
-                s = s.replace("{{" + k + "}}", v)
-            return s
+            exported = {
+                k: exported.get(k, os.environ.get(k, ""))
+                for k in wanted
+                if isinstance(k, str) and (k in exported or k in os.environ)
+            }
+        inherited = {k: v for k, v in os.environ.items() if not k.startswith("LINEAR_")}
 
         argv = [str(path), *(interp(str(a)) for a in (cfg.get("args") or []))]
         try:
             subprocess.Popen(
                 argv,
-                env={**os.environ, **exported, "LINEAR_TOOL_COMMAND": "ltui"},
+                env={**inherited, **exported, "LINEAR_TOOL_COMMAND": "ltui"},
                 stdin=subprocess.DEVNULL,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,


### PR DESCRIPTION
### the gap

Linear's desktop app can hand an issue to a local script — **Work on issue → Custom script**, configured in `~/.linear/coding-tools.json`. ltui has no equivalent. `config.json` only remaps the built-in actions, so there's no way to get a ticket out to a coding agent without copying the branch name by hand and switching apps — which is exactly the context switch ltui otherwise removes.

### the change

A `run_script` action, bound to `x`, that reads **that same file**. No second config to keep in sync: if you already use the feature in the desktop app, `x` works in ltui immediately with the script you've already written.

```jsonc
// ~/.linear/coding-tools.json
{
  "openIssue": {
    "path": "/absolute/path/to/your-script",
    "args": ["--branch", "{{issue.branchName}}"],
    "env": ["LINEAR_PROMPT", "LINEAR_ISSUE_IDENTIFIER", "LINEAR_ISSUE_BRANCH_NAME"]
  }
}
```

It follows Linear's contract rather than inventing one: `{{...}}` interpolation in `args`, and `env` as an allowlist over the `LINEAR_*` variables (omit it and all are exported). `LINEAR_TOOL_COMMAND=ltui` is always set, so a script shared between the two can tell which fired it.

`LINEAR_PROMPT` is rendered from `~/.linear/prompt-template.txt` — the counterpart to Linear's **Prompt template** setting — falling back to `{{context}}`, the ticket's title and description.

### notes

- The child runs with `start_new_session=True` and stdio to `/dev/null`, so it can't fight Textual for the tty.
- Missing or malformed config surfaces as a notification, never a traceback. With no `coding-tools.json` present, `x` is inert — nothing changes for anyone not using it.
- `x` was free; it's remappable like everything else, and lands in `--init-config`, the `?` modal and `--help`.
- Dependencies unchanged (`os` + `subprocess` from stdlib).

### open question

`~/.linear/prompt-template.txt` is my own convention, not one of Linear's — Linear keeps that template server-side and only exposes the rendered result. Happy to rename it, or move it into `coding-tools.json` as a `promptTemplate` key, if you'd rather it not claim a new path.

### testing

Exercised end-to-end against a stub script: `args` interpolation, multi-word values surviving as single argv entries, the `env` allowlist correctly withholding unlisted variables, and the template rendering. Also driven against a real script that opens a remote agent session, which is what prompted the patch.
